### PR TITLE
Add JSON output support with --json flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,10 +4,11 @@ PoCForge - CVE-to-PoC Generator using PyGithub with uv
 Run with: uv run main.py
 """
 
+import json
 import logging
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import typer
 from github import Github
@@ -20,7 +21,7 @@ from cve_tracker.poc_generator import generate_poc_from_fix_commit
 logging.basicConfig(level=logging.WARNING, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
-def fetch_recent_cves(token: Optional[str] = None, hours: int = 24, target_cve: Optional[str] = None) -> None:
+def fetch_recent_cves(token: Optional[str] = None, hours: int = 24, target_cve: Optional[str] = None, json_output: bool = False) -> None:
     """
     Fetch and print CVEs from the last N hours using PyGithub.
 
@@ -28,6 +29,7 @@ def fetch_recent_cves(token: Optional[str] = None, hours: int = 24, target_cve: 
         token: GitHub personal access token (optional)
         hours: Hours to look back (default: 24)
         target_cve: Specific CVE ID to target (e.g., CVE-2024-1234)
+        json_output: Output results in JSON format instead of human-readable
     """
     # Calculate date threshold (timezone-aware)
     since = datetime.now(timezone.utc) - timedelta(hours=hours)
@@ -35,12 +37,23 @@ def fetch_recent_cves(token: Optional[str] = None, hours: int = 24, target_cve: 
     # Initialize GitHub client
     g = Github(token) if token else Github()
 
+    # Initialize results structure for JSON output
+    results: Dict[str, Any] = {
+        "search_params": {"hours": hours, "target_cve": target_cve, "timestamp": datetime.now(timezone.utc).isoformat()},
+        "cves": [],
+        "summary": {},
+    }
+
     try:
-        if target_cve:
-            print(f"Targeting specific CVE: {target_cve}")
+        if not json_output:
+            if target_cve:
+                print(f"Targeting specific CVE: {target_cve}")
+            else:
+                print(f"Fetching CVEs from the last {hours} hours...")
             print("🧪 PoCForge: Creating vulnerability demonstrations from fix commits")
             print("=" * 60)
 
+        if target_cve:
             # Direct CVE lookup using GitHub API filtering
             logging.info(f"Searching for specific CVE: {target_cve}")
             try:
@@ -52,20 +65,28 @@ def fetch_recent_cves(token: Optional[str] = None, hours: int = 24, target_cve: 
                 try:
                     first_page = advisories.get_page(0)
                     if not first_page:
-                        print(f"❌ CVE {target_cve} not found in GitHub Security Advisories")
+                        if not json_output:
+                            print(f"❌ CVE {target_cve} not found in GitHub Security Advisories")
+                        else:
+                            results["error"] = f"CVE {target_cve} not found in GitHub Security Advisories"
+                            print(json.dumps(results, indent=2))
                         return
                 except Exception:
-                    print(f"❌ CVE {target_cve} not found in GitHub Security Advisories")
+                    if not json_output:
+                        print(f"❌ CVE {target_cve} not found in GitHub Security Advisories")
+                    else:
+                        results["error"] = f"CVE {target_cve} not found in GitHub Security Advisories"
+                        print(json.dumps(results, indent=2))
                     return
 
             except Exception as e:
-                print(f"❌ Error searching for CVE {target_cve}: {e}")
+                if not json_output:
+                    print(f"❌ Error searching for CVE {target_cve}: {e}")
+                else:
+                    results["error"] = f"Error searching for CVE {target_cve}: {e}"
+                    print(json.dumps(results, indent=2))
                 return
         else:
-            print(f"Fetching CVEs from the last {hours} hours...")
-            print("🧪 PoCForge: Creating vulnerability demonstrations from fix commits")
-            print("=" * 60)
-
             # Get security advisories for time-based search
             # Note: GitHub API doesn't support time filtering, so we fetch recent ones
             logging.info("Fetching global advisories from GitHub...")
@@ -83,18 +104,41 @@ def fetch_recent_cves(token: Optional[str] = None, hours: int = 24, target_cve: 
 
             count += 1
 
-            print(f"\n🚨 CVE: {advisory.cve_id or 'N/A'}")
-            print(f"📝 Summary: {advisory.summary}")
-            print(f"⚠️  Severity: {advisory.severity.upper()}")
-            print(f"📅 Published: {advisory.published_at}")
+            # Create CVE data structure
+            cve_data: Dict[str, Any] = {
+                "cve_id": advisory.cve_id or "N/A",
+                "summary": advisory.summary,
+                "severity": advisory.severity.upper() if advisory.severity else "UNKNOWN",
+                "published_at": advisory.published_at.isoformat() if advisory.published_at else None,
+                "packages": [],
+                "pocs_generated": 0,
+            }
+
+            if not json_output:
+                print(f"\n🚨 CVE: {cve_data['cve_id']}")
+                print(f"📝 Summary: {cve_data['summary']}")
+                print(f"⚠️  Severity: {cve_data['severity']}")
+                print(f"📅 Published: {advisory.published_at}")
 
             # Focus on affected packages for PR correlation
             if advisory.vulnerabilities:
                 for vuln in advisory.vulnerabilities:
                     pkg = vuln.package
-                    print(f"\n📦 Package: {pkg.name} ({pkg.ecosystem})")
-                    print(f"   Vulnerable: {vuln.vulnerable_version_range}")
-                    print(f"   Patched: {vuln.patched_versions}")
+
+                    # Create package data structure
+                    package_data: Dict[str, Any] = {
+                        "name": pkg.name or "unknown",
+                        "ecosystem": pkg.ecosystem or "unknown",
+                        "vulnerable_versions": vuln.vulnerable_version_range or "unknown",
+                        "patched_versions": vuln.patched_versions or "unknown",
+                        "commits": [],
+                        "pocs": [],
+                    }
+
+                    if not json_output:
+                        print(f"\n📦 Package: {package_data['name']} ({package_data['ecosystem']})")
+                        print(f"   Vulnerable: {package_data['vulnerable_versions']}")
+                        print(f"   Patched: {package_data['patched_versions']}")
 
                     if not (pkg.name and pkg.ecosystem):
                         continue
@@ -105,14 +149,26 @@ def fetch_recent_cves(token: Optional[str] = None, hours: int = 24, target_cve: 
                     total_packages += 1
 
                     if advisory_commits:
-                        print(f"   ✅ Found {len(advisory_commits)} fix commits from security advisory:")
+                        if not json_output:
+                            print(f"   ✅ Found {len(advisory_commits)} fix commits from security advisory:")
 
                         for commit_info in advisory_commits:
-                            message = commit_info["message"]
-                            print(f"      🔧 {message}")
-                            print(f"         📄 {commit_info['url']}")
-                            print(f"         🏢 {commit_info['repo']}")
-                            print(f"         📅 {commit_info['date']}")
+                            # Add commit info to package data
+                            commit_data = {
+                                "url": commit_info["url"],
+                                "sha": commit_info["sha"],
+                                "message": commit_info["message"],
+                                "repo": commit_info["repo"],
+                                "date": commit_info["date"],
+                            }
+                            package_data["commits"].append(commit_data)
+
+                            if not json_output:
+                                message = commit_info["message"]
+                                print(f"      🔧 {message}")
+                                print(f"         📄 {commit_info['url']}")
+                                print(f"         🏢 {commit_info['repo']}")
+                                print(f"         📅 {commit_info['date']}")
 
                             # Generate PoC from fix commit
                             try:
@@ -162,49 +218,90 @@ def fetch_recent_cves(token: Optional[str] = None, hours: int = 24, target_cve: 
                                             method_note = ""
                                             if diff_size > 12000:
                                                 method_note = " (using git extraction)"
-                                            print(f"         🧪 Generated PoC{method_note}:")
-                                            if poc_data["vulnerable_function"]:
-                                                print(f"            🎯 Vulnerable: {poc_data['vulnerable_function']}")
-                                            if poc_data["prerequisites"]:
-                                                prereqs = ", ".join(poc_data["prerequisites"][:3])
-                                                print(f"            📋 Prerequisites: {prereqs}")
-                                            if poc_data["attack_vector"]:
-                                                print(f"            💥 Attack: {poc_data['attack_vector']}")
-                                            if poc_data["vulnerable_code"]:
-                                                print("            🐛 Vulnerable Code:")
-                                                print(f"               {poc_data['vulnerable_code']}")
-                                            if poc_data["fixed_code"]:
-                                                print("            ✅ Fixed Code:")
-                                                print(f"               {poc_data['fixed_code']}")
-                                            if poc_data["test_case"]:
-                                                print("            🧪 Test Case:")
-                                                print(f"               {poc_data['test_case']}")
-                                            if poc_data["reasoning"]:
-                                                print("            💡 Reasoning:")
-                                                print(f"               {poc_data['reasoning']}")
+
+                                            # Add PoC to package data
+                                            package_data["pocs"].append(
+                                                {
+                                                    "commit_url": commit_info["url"],
+                                                    "commit_sha": commit_info["sha"],
+                                                    "vulnerable_function": poc_data.get("vulnerable_function"),
+                                                    "attack_vector": poc_data.get("attack_vector"),
+                                                    "vulnerable_code": poc_data.get("vulnerable_code"),
+                                                    "fixed_code": poc_data.get("fixed_code"),
+                                                    "test_case": poc_data.get("test_case"),
+                                                    "prerequisites": poc_data.get("prerequisites"),
+                                                    "reasoning": poc_data.get("reasoning"),
+                                                    "method": "git_extraction" if diff_size > 12000 else "direct",
+                                                }
+                                            )
+
+                                            if not json_output:
+                                                print(f"         🧪 Generated PoC{method_note}:")
+                                                if poc_data["vulnerable_function"]:
+                                                    print(f"            🎯 Vulnerable: {poc_data['vulnerable_function']}")
+                                                if poc_data["prerequisites"]:
+                                                    prereqs = ", ".join(poc_data["prerequisites"][:3])
+                                                    print(f"            📋 Prerequisites: {prereqs}")
+                                                if poc_data["attack_vector"]:
+                                                    print(f"            💥 Attack: {poc_data['attack_vector']}")
+                                                if poc_data["vulnerable_code"]:
+                                                    print("            🐛 Vulnerable Code:")
+                                                    print(f"               {poc_data['vulnerable_code']}")
+                                                if poc_data["fixed_code"]:
+                                                    print("            ✅ Fixed Code:")
+                                                    print(f"               {poc_data['fixed_code']}")
+                                                if poc_data["test_case"]:
+                                                    print("            🧪 Test Case:")
+                                                    print(f"               {poc_data['test_case']}")
+                                                if poc_data["reasoning"]:
+                                                    print("            💡 Reasoning:")
+                                                    print(f"               {poc_data['reasoning']}")
                                         else:
                                             reason = poc_data["reasoning"][:50]
-                                            print(f"         ⚠️  PoC generation failed: {reason}")
+                                            if not json_output:
+                                                print(f"         ⚠️  PoC generation failed: {reason}")
 
                             except Exception as e:
-                                print(f"         ⚠️  PoC generation error: {str(e)[:50]}")
+                                if not json_output:
+                                    print(f"         ⚠️  PoC generation error: {str(e)[:50]}")
                     else:
-                        print("   ❌ No fix commits found in advisory references")
+                        if not json_output:
+                            print("   ❌ No fix commits found in advisory references")
 
-            print("\n" + "=" * 80)
+                    # Add package to CVE data
+                    cve_data["packages"].append(package_data)
+                    cve_data["pocs_generated"] += len(package_data["pocs"])
+
+            if not json_output:
+                print("\n" + "=" * 80)
 
             # Limit output for manageable processing
             if not target_cve and count >= 5:
-                print("(Showing first 5 results...)")
+                if not json_output:
+                    print("(Showing first 5 results...)")
                 break
 
-        print(f"\nFound {count} recent CVEs")
-        print("📊 PoC Generation Summary:")
-        print(f"   Total packages analyzed: {total_packages}")
-        print(f"   🧪 PoCs generated: {poc_generated_count}")
-        if total_packages > 0:
-            success_rate = (poc_generated_count / total_packages) * 100
-            print(f"   📈 PoC generation rate: {success_rate:.1f}%")
+            # Add CVE to results
+            results["cves"].append(cve_data)
+
+        # Output results
+        results["summary"] = {
+            "total_cves": count,
+            "total_packages": total_packages,
+            "pocs_generated": poc_generated_count,
+            "success_rate": (poc_generated_count / total_packages * 100) if total_packages > 0 else 0,
+        }
+
+        if json_output:
+            print(json.dumps(results, indent=2))
+        else:
+            print(f"\nFound {count} recent CVEs")
+            print("📊 PoC Generation Summary:")
+            print(f"   Total packages analyzed: {total_packages}")
+            print(f"   🧪 PoCs generated: {poc_generated_count}")
+            if total_packages > 0:
+                success_rate = (poc_generated_count / total_packages) * 100
+                print(f"   📈 PoC generation rate: {success_rate:.1f}%")
 
     except Exception as e:
         print(f"Error: {e}")
@@ -225,6 +322,7 @@ app = typer.Typer(help="PoCForge - CVE-to-PoC Generator")
 def main(
     hours: int = typer.Option(24, "--hours", "-h", help="Hours to look back for recent CVEs"),
     cve: Optional[str] = typer.Option(None, "--cve", "-c", help="Target specific CVE (e.g., CVE-2024-1234)"),
+    json_output: bool = typer.Option(False, "--json", help="Output results in JSON format"),
 ) -> None:
     """
     PoCForge - Generate Proof-of-Concept demonstrations from CVE fix commits.
@@ -233,26 +331,31 @@ def main(
         uv run main.py                          # Last 24 hours
         uv run main.py --hours 48               # Last 48 hours
         uv run main.py --cve CVE-2024-1234      # Specific CVE
+        uv run main.py --json                   # JSON output
+        uv run main.py --cve CVE-2024-1234 --json  # Specific CVE as JSON
     """
-    print("PoCForge - CVE-to-PoC Generator")
+    if not json_output:
+        print("PoCForge - CVE-to-PoC Generator")
 
     # Get tokens from config
     token = get_github_token()
     anthropic_key = get_anthropic_api_key()
 
     if not token:
-        print("Tip: Add GitHub token to config.json for higher rate limits")
+        if not json_output:
+            print("Tip: Add GitHub token to config.json for higher rate limits")
         logging.warning("No GITHUB_TOKEN found - using unauthenticated requests")
     else:
         logging.info(f"Using GITHUB_TOKEN from config (starts with: {token[:8]}...)")
 
     if not anthropic_key:
-        print("Warning: No Anthropic API key found - PoC generation will be disabled")
-        print("Add your key to config.json or set ANTHROPIC_API_KEY environment variable")
+        if not json_output:
+            print("Warning: No Anthropic API key found - PoC generation will be disabled")
+            print("Add your key to config.json or set ANTHROPIC_API_KEY environment variable")
     else:
         logging.info("Using Anthropic API key from config")
 
-    fetch_recent_cves(token, hours=hours, target_cve=cve)
+    fetch_recent_cves(token, hours=hours, target_cve=cve, json_output=json_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds JSON output support for programmatic use of PoCForge results.

## Changes

### JSON Output Flag
- `--json` flag to output structured JSON instead of human-readable text
- Suppresses all human-readable output when JSON mode is enabled
- Clean output suitable for piping to `jq` or other JSON processors

### Data Collection
- Comprehensive JSON structure with CVE details, packages, commits, and PoCs
- Search parameters and metadata included in output
- Summary statistics for analysis results

### Silent Mode
- No banner or status messages in JSON mode
- All warnings and tips suppressed for clean JSON output
- Maintains logging for debugging but keeps stdout clean

## JSON Structure

```json
{
  "search_params": {
    "hours": 24,
    "target_cve": "CVE-2024-1234", 
    "timestamp": "2025-07-09T04:36:04Z"
  },
  "cves": [{
    "cve_id": "CVE-2024-1234",
    "summary": "...",
    "severity": "HIGH",
    "published_at": "2024-08-30T03:30:44Z",
    "packages": [{
      "name": "example-package",
      "ecosystem": "npm",
      "vulnerable_versions": "< 2.6.3",
      "commits": [{"url": "...", "sha": "...", "message": "..."}],
      "pocs": [{"vulnerable_function": "...", "attack_vector": "..."}]
    }],
    "pocs_generated": 1
  }],
  "summary": {
    "total_cves": 1,
    "total_packages": 1, 
    "pocs_generated": 1,
    "success_rate": 100.0
  }
}
```

## Usage

```bash
# Human-readable output (default)
uv run main.py --cve CVE-2024-1234

# Machine-readable JSON output
uv run main.py --cve CVE-2024-1234 --json

# Process with jq
uv run main.py --json --hours 48 | jq '.summary'
```

## Testing

- JSON output validates with `jq`
- All existing functionality preserved
- Human-readable mode unchanged
- Type annotations added for data structures

## Test plan

- [x] Test JSON output with specific CVE
- [x] Test JSON output with time-based search
- [x] Verify human-readable mode still works
- [x] Run all tests and linting
- [x] Verify no human output in JSON mode