### PR TITLE
Add code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,7 @@ jobs:
       run: uv run mypy .
     
     - name: Run tests with coverage
-      run: uv run pytest --cov=. --cov=cve_tracker --cov-report=term-missing --cov-report=xml tests/ -v
-    
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: false
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      if: ${{ secrets.CODECOV_TOKEN }}
+      run: uv run pytest --cov=. --cov=cve_tracker --cov-report=term-missing tests/ -v
     
     - name: Generate coverage summary
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,14 @@ jobs:
         fail_ci_if_error: false
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      if: ${{ secrets.CODECOV_TOKEN }}
+    
+    - name: Generate coverage summary
+      run: |
+        echo "## Coverage Report" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        uv run coverage report >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
     
     - name: Test basic functionality (dry run)
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,12 @@ uv run pytest --cov=. --cov=cve_tracker --cov-report=term-missing --cov-report=h
 uv run coverage report --show-missing
 ```
 
+#### Coverage Integration
+- **CI**: GitHub Actions automatically runs coverage on all PRs and pushes
+- **Codecov**: Optional external coverage tracking (requires `CODECOV_TOKEN` secret)
+- **Reports**: HTML coverage reports generated in `htmlcov/` directory
+- **Current Coverage**: 48.05% baseline with detailed missing line reports
+
 ### Git Hooks
 - Pre-push hook automatically runs ruff format --check, ruff check, and mypy
 - Install hooks: `./setup-hooks.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,6 @@ uv run coverage report --show-missing
 
 #### Coverage Integration
 - **CI**: GitHub Actions automatically runs coverage on all PRs and pushes
-- **Codecov**: Optional external coverage tracking (requires `CODECOV_TOKEN` secret)
 - **Reports**: HTML coverage reports generated in `htmlcov/` directory
 - **Current Coverage**: 48.05% baseline with detailed missing line reports
 


### PR DESCRIPTION
## Summary

Adds comprehensive code coverage tooling to track test coverage and identify untested code.

## Changes

### Coverage Dependencies
- `coverage>=7.0.0` - Core coverage measurement tool
- `pytest-cov>=4.0.0` - Pytest plugin for coverage integration

### Configuration
- Coverage settings in `pyproject.toml`
- Source paths: current directory and `cve_tracker/`
- Excludes test files, venv, and common patterns
- HTML report generation in `htmlcov/` directory

### Development Commands
- `uv run pytest --cov=. --cov=cve_tracker` - Run tests with coverage
- `uv run coverage report` - Generate terminal coverage report
- `uv run coverage html` - Generate HTML coverage report
- Combined: `uv run pytest --cov=. --cov=cve_tracker --cov-report=term-missing --cov-report=html`

### CI Integration
- Updated GitHub Actions workflow to run coverage with tests
- Coverage summary displayed in GitHub Actions step summary
- No external dependencies or tokens required

### Current Coverage
- **Total: 48.05%** - Baseline coverage with existing tests
- `cve_tracker/github_search.py`: 100% (fully covered)
- `cve_tracker/config.py`: 72.41% (missing error handling paths)
- `cve_tracker/poc_generator.py`: 45.28% (missing AI integration paths)
- `main.py`: 41.21% (missing CLI execution paths)

## Files Modified

- `pyproject.toml` - Added coverage dependencies and configuration
- `.github/workflows/ci.yml` - Added coverage reporting to CI
- `CLAUDE.md` - Added coverage commands documentation
- `.gitignore` - Added coverage output directories

## Test plan

- [x] Coverage tools install correctly
- [x] Coverage reports generate successfully
- [x] HTML reports are created in `htmlcov/`
- [x] CI workflow includes coverage step
- [x] All existing tests pass with coverage enabled
- [x] Coverage configuration excludes appropriate files
- [x] CI works without external dependencies

## Usage

After merging, developers can run:
```bash
# Quick coverage check
uv run pytest --cov=. --cov=cve_tracker

# Detailed coverage with HTML report
uv run pytest --cov=. --cov=cve_tracker --cov-report=term-missing --cov-report=html
```

The CI will automatically show coverage results in the GitHub Actions summary for every PR.